### PR TITLE
SC 11529 - Add PHP 8.1 support to php-cache package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Notice! ⚠️
+
+This is a forked and repackaged version of the [PHP Cache](https://github.com/php-cache/cache) package, to enable support for PHP 8.1 and to serve as an internal dependency for Foodkit applications.
+
 # PHP Cache
 
 [![Gitter](https://badges.gitter.im/php-cache/cache.svg)](https://gitter.im/php-cache/cache?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
@@ -5,13 +9,13 @@
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
 [![StyleCI](https://styleci.io/repos/50789153/shield)](https://styleci.io/repos/50789153)
 
-This is the main repository for all our cache adapters and libraries. To read about 
-features like tagging and hierarchy support please read the shared documentation at [www.php-cache.com](http://www.php-cache.com). 
+This is the main repository for all our cache adapters and libraries. To read about
+features like tagging and hierarchy support please read the shared documentation at [www.php-cache.com](http://www.php-cache.com).
 
 Back in 2016, this was the first library supporting PSR-6. We created Symfony bundles
-and made many great libraries in the PHP-cache organization. This was a few years ago 
-and the library is not activly maintained. Starting a new project one should consider 
-using the more performant and activly supported 
+and made many great libraries in the PHP-cache organization. This was a few years ago
+and the library is not activly maintained. Starting a new project one should consider
+using the more performant and activly supported
 [Symfony Cache](https://symfony.com/doc/current/components/cache.html).
 
 ### Notice

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "cache/cache",
+    "name": "foodkit/cache",
     "description": "Library of all the php-cache adapters",
     "license": "MIT",
     "type": "library",
@@ -21,7 +21,7 @@
     ],
     "homepage": "http://www.php-cache.com/en/latest/",
     "require": {
-        "php": ">=7.4",
+        "php": "^7.4|^8",
         "doctrine/cache": "^1.3",
         "league/flysystem": "^1.0",
         "psr/cache": "^1.0 || ^2.0",
@@ -101,10 +101,5 @@
         "exclude-from-classmap": [
             "**/Tests/"
         ]
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.1-dev"
-        }
     }
 }


### PR DESCRIPTION
This PR adds PHP 8.1 support to php-cache package.

| Question      | Answer
| ------------- | ------
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no